### PR TITLE
fix: "translate" & "display IPA" have no response

### DIFF
--- a/enjoy/src/renderer/components/medias/media-caption.tsx
+++ b/enjoy/src/renderer/components/medias/media-caption.tsx
@@ -65,7 +65,7 @@ export const MediaCaption = (props: {
   const { EnjoyApp } = useContext(AppSettingsProviderContext);
   const { openai } = useContext(AISettingsProviderContext);
 
-  const toogleIPA = async () => {
+  const toggleIPA = async () => {
     if (ipaGenerating) return;
 
     if (ipa.length > 0) {
@@ -79,6 +79,7 @@ export const MediaCaption = (props: {
     const cached = await EnjoyApp.cacheObjects.get(cacheKey);
     if (cached) {
       setIpa(cached);
+      setDisplayIpa(true);
       return;
     }
 
@@ -119,6 +120,7 @@ export const MediaCaption = (props: {
     const cached = await EnjoyApp.cacheObjects.get(cacheKey);
     if (cached) {
       setTranslation(cached);
+      setDisplayTranslation(true);
       return;
     }
 
@@ -235,7 +237,7 @@ export const MediaCaption = (props: {
             <DropdownMenuItem
               className="cursor-pointer capitalize"
               disabled={ipaGenerating}
-              onClick={toogleIPA}
+              onClick={toggleIPA}
             >
               {ipaGenerating ? (
                 <LoaderIcon className="w-4 h-4 mr-2 animate-spin" />


### PR DESCRIPTION
当A片段翻译与标注音标的内容被缓存以后，切换到B片段再切换回A片段后，再次点击“翻译”与“标注音标”是不响应的。针对此bug修复。