### PR TITLE
Fix youtubedr directory

### DIFF
--- a/enjoy/src/main/youtubedr.ts
+++ b/enjoy/src/main/youtubedr.ts
@@ -10,7 +10,11 @@ import url from "url";
 import mainWin from "@main/window";
 
 const __filename = url.fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+
+//  youtubedr bin file will be in /app.asar.unpacked instead of /app.asar
+const __dirname = path
+  .dirname(__filename)
+  .replace("app.asar", "app.asar.unpacked");
 
 const logger = log.scope("YOUTUBEDR");
 


### PR DESCRIPTION
The production app is searching for youtubedr bin file in a wrong location
![image](https://github.com/xiaolai/everyone-can-use-english/assets/12432409/9160b5da-86c1-441f-8911-1e3611211802)

Same had happened to ffmeg https://github.com/xiaolai/everyone-can-use-english/blob/main/enjoy/src/main/ffmpeg.ts#L14

This should fix the Youtube video download issue